### PR TITLE
fix failing to load ASMInit in CCL

### DIFF
--- a/src/main/resources/dependencies.info
+++ b/src/main/resources/dependencies.info
@@ -1,0 +1,7 @@
+{
+	"repo": "http://files.minecraftforge.net/maven/codechicken/CodeChickenLib/1.7.10-1.1.3.138/",
+	"file": "CodeChickenLib-1.7.10-1.1.3.138-universal.jar",
+	"dev": "CodeChickenLib-1.7.10-1.1.3.138-dev.jar",
+	"class": "codechicken.lib.asm.ASMHelper",
+	"coreLib": true
+}


### PR DESCRIPTION
partially reverts ec6541e17fd9311550911432beb5cb2c9fdc119b

context: https://discordapp.com/channels/181078474394566657/603348502637969419/780904519461765151

I don't know what's behind this magic, but it works just fine.