### PR TITLE
add an early low memory error to GTNH

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@ autoUpdateBuildScript = false
 minecraftVersion = 1.7.10
 forgeVersion = 10.13.4.1614
 
-# Select a username for testing your mod with breakpoints. You may leave this empty for a random user name each time you
+# Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
 # restart Minecraft in development. Choose this dependent on your mod:
 # Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
 # Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
-developmentEnvironmentUserName = "Developer"
+developmentEnvironmentUserName = Developer
 
 # Define a source file of your project with:
 # public static final String VERSION = "GRADLETOKEN_VERSION";
-# The string's content will be replaced with your mods version when compiled. You should use this to specify your mod's
+# The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
 replaceGradleTokenInFile = CodeChickenCoreModContainer.java
@@ -32,7 +32,7 @@ gradleTokenModName = GRADLETOKEN_MODNAME
 gradleTokenVersion = GRADLETOKEN_VERSION
 gradleTokenGroupName =
 
-# In case your mod provides an API for other mods to implement you may declare its package here. Otherwise you can
+# In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
 # Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
 apiPackage =
@@ -48,7 +48,7 @@ mixinPlugin =
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage =
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
-# This parameter is for legacy compatability only
+# This parameter is for legacy compatibility only
 # Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
 coreModClass = core.launch.CodeChickenCorePlugin
 # If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class

--- a/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
+++ b/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
@@ -124,7 +124,7 @@ public class CodeChickenCorePlugin implements IFMLLoadingPlugin, IFMLCallHook
     public static void systemCheck(String minRAM) {
         long minBytes = parseSize(minRAM);
         if (Runtime.getRuntime().maxMemory() < minBytes) {
-            String err = "You should have at least " + minRAM + "of RAM but you have only allocated " + humanReadableByteCountBin(Runtime.getRuntime().maxMemory()) + ".";
+            String err = "You should have at least " + minRAM + " of RAM but you have only allocated " + humanReadableByteCountBin(Runtime.getRuntime().maxMemory()) + ".";
             logger.error(err);
 
             JEditorPane ep = new JEditorPane("text/html",

--- a/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
+++ b/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.text.CharacterIterator;
-import java.text.NumberFormat;
 import java.text.StringCharacterIterator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
+++ b/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
@@ -118,7 +118,7 @@ public class CodeChickenCorePlugin implements IFMLLoadingPlugin, IFMLCallHook
             ci.next();
         }
         value *= Long.signum(bytes);
-        return String.format("%.1f %ciB", value / 1024.0, ci.current());
+        return String.format("%.1f %cB", value / 1024.0, ci.current());
     }
 
     public static void systemCheck(String minRAM) {

--- a/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
+++ b/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
@@ -149,7 +149,7 @@ public class CodeChickenCorePlugin implements IFMLLoadingPlugin, IFMLCallHook
 
             if (!GraphicsEnvironment.isHeadless())
                 JOptionPane.showMessageDialog(null, ep, "lol nope", JOptionPane.ERROR_MESSAGE);
-            FMLCommonHandler.instance().exitJava(-99, true);
+            FMLCommonHandler.instance().exitJava(-98, true);
         }
     }
 

--- a/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
+++ b/src/main/java/codechicken/core/launch/CodeChickenCorePlugin.java
@@ -1,9 +1,12 @@
 package codechicken.core.launch;
 
-import java.awt.Desktop;
+import java.awt.*;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.text.CharacterIterator;
+import java.text.NumberFormat;
+import java.text.StringCharacterIterator;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -16,6 +19,7 @@ import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
 import codechicken.core.asm.*;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.CoreModManager;
 
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
@@ -91,6 +95,64 @@ public class CodeChickenCorePlugin implements IFMLLoadingPlugin, IFMLCallHook
         }
     }
 
+    public static long parseSize(String text) {
+        double d = Double.parseDouble(text.replaceAll("[GMK]B?$", ""));
+        long l = Math.round(d * 1024 * 1024 * 1024L);
+        switch (text.replaceAll("\\d?","").toUpperCase().charAt(0)) {
+            default:  l /= 1024;
+            case 'K': l /= 1024;
+            case 'M': l /= 1024;
+            case 'G': return l;
+        }
+    }
+
+    public static String humanReadableByteCountBin(long bytes) {
+        long absB = bytes == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(bytes);
+        if (absB < 1024) {
+            return bytes + " B";
+        }
+        long value = absB;
+        CharacterIterator ci = new StringCharacterIterator("KMGTPE");
+        for (int i = 40; i >= 0 && absB > 0xfffccccccccccccL >> i; i -= 10) {
+            value >>= 10;
+            ci.next();
+        }
+        value *= Long.signum(bytes);
+        return String.format("%.1f %ciB", value / 1024.0, ci.current());
+    }
+
+    public static void systemCheck(String minRAM) {
+        long minBytes = parseSize(minRAM);
+        if (Runtime.getRuntime().maxMemory() < minBytes) {
+            String err = "You should have at least " + minRAM + "of RAM but you have only allocated " + humanReadableByteCountBin(Runtime.getRuntime().maxMemory()) + ".";
+            logger.error(err);
+
+            JEditorPane ep = new JEditorPane("text/html",
+                    "<html>" +
+                            err +
+                            "<br>GTNH seriously won't run without enough RAM. See <a href=\"https://gtnh.miraheze.org/m/3S2\">the Wiki</a> for details." +
+                            "<br>Recommended values are between 4GB and 6GB. Check your launcher's JVM arguments." +
+                            "</html>");
+
+            ep.setEditable(false);
+            ep.setOpaque(false);
+            ep.addHyperlinkListener(new HyperlinkListener()
+            {
+                @Override
+                public void hyperlinkUpdate(HyperlinkEvent event) {
+                    try {
+                        if (event.getEventType().equals(HyperlinkEvent.EventType.ACTIVATED))
+                            Desktop.getDesktop().browse(event.getURL().toURI());
+                    } catch (Exception ignored) {}
+                }
+            });
+
+            if (!GraphicsEnvironment.isHeadless())
+                JOptionPane.showMessageDialog(null, ep, "lol nope", JOptionPane.ERROR_MESSAGE);
+            FMLCommonHandler.instance().exitJava(-99, true);
+        }
+    }
+
     @Override
     public String[] getASMTransformerClass() {
         versionCheck(mcVersion, "CodeChickenCore");
@@ -124,6 +186,7 @@ public class CodeChickenCorePlugin implements IFMLLoadingPlugin, IFMLCallHook
     @Override
     public Void call() {
         CodeChickenCoreModContainer.loadConfig();
+        systemCheck(CodeChickenCoreModContainer.config.getTag("minRAM").getValue("3GB"));
         TweakTransformer.load();
         scanCodeChickenMods();
 

--- a/src/main/java/codechicken/core/launch/DepLoader.java
+++ b/src/main/java/codechicken/core/launch/DepLoader.java
@@ -186,7 +186,7 @@ public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
                 }
             });
 
-            JOptionPane.showMessageDialog(null, ep, "A download error has occured", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, ep, "A download error has occurred", JOptionPane.ERROR_MESSAGE);
         }
     }
 


### PR DESCRIPTION
See https://discordapp.com/channels/181078474394566657/234936569360809996/926665005959622657

This will check and error out if the RAM is not enough. It defaults to 3GB (configurable) and works on server and client, throwing a nice message on client (forced it to 30GB to show):

<img width="850" alt="image" src="https://user-images.githubusercontent.com/533931/147844152-2fac34bc-656e-4cec-af40-60e45c90b656.png">

The server-side message is not as pretty because I can't suppress the forge barf, but it shows:

```
[22:36:03] [main/DEBUG] [FML/]: Running coremod plugin for CodeChickenCorePlugin {codechicken.core.launch.CodeChickenCorePlugin}
[22:36:03] [main/DEBUG] [FML/]: Running coremod plugin CodeChickenCorePlugin
[22:36:03] [main/ERROR] [CodeChickenCore/]: You should have at least 30GB but you have allocated 6.0 GiB.
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: java.lang.reflect.InvocationTargetException
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.relauncher.ServerLaunchWrapper.run(ServerLaunchWrapper.java:43)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.relauncher.ServerLaunchWrapper.main(ServerLaunchWrapper.java:12)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: Caused by: java.lang.ExceptionInInitializerError
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at codechicken.core.launch.CodeChickenCorePlugin.systemCheck(CodeChickenCorePlugin.java:152)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at codechicken.core.launch.CodeChickenCorePlugin.call(CodeChickenCorePlugin.java:189)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at codechicken.core.launch.CodeChickenCorePlugin.call(CodeChickenCorePlugin.java:34)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.relauncher.CoreModManager$FMLPluginWrapper.injectIntoClassLoader(CoreModManager.java:133)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:115)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	... 6 more
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: Caused by: java.lang.NullPointerException
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.common.Loader.<init>(Loader.java:198)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.common.Loader.instance(Loader.java:176)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.common.FMLCommonHandler.<init>(FMLCommonHandler.java:87)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at cpw.mods.fml.common.FMLCommonHandler.<clinit>(FMLCommonHandler.java:77)
[22:36:03] [main/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	... 12 more
```