### PR TITLE
Reduce RAM allocations during rendering

### DIFF
--- a/src/main/java/codechicken/lib/render/CCModelLibrary.java
+++ b/src/main/java/codechicken/lib/render/CCModelLibrary.java
@@ -5,7 +5,6 @@ import static codechicken.lib.math.MathHelper.phi;
 import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.Quat;
 import codechicken.lib.vec.Rotation;
-import codechicken.lib.vec.Scale;
 import codechicken.lib.vec.Vector3;
 
 public class CCModelLibrary {
@@ -82,7 +81,12 @@ public class CCModelLibrary {
         i++;
     }
 
+    @Deprecated
     public static Matrix4 getRenderMatrix(Vector3 position, Rotation rotation, double scale) {
-        return new Matrix4().translate(position).apply(new Scale(scale)).apply(rotation);
+        return new Matrix4().translate(position).scale(scale).apply(rotation);
+    }
+
+    public static Matrix4 getRenderMatrix(double posX, double posY, double posZ, Rotation rotation, double scale) {
+        return new Matrix4().translate(posX, posY, posZ).scale(scale).apply(rotation);
     }
 }

--- a/src/main/java/codechicken/lib/render/RenderUtils.java
+++ b/src/main/java/codechicken/lib/render/RenderUtils.java
@@ -66,7 +66,7 @@ public class RenderUtils {
      * @param res  Units per icon
      */
     public static void renderFluidQuad(Vector3 base, Vector3 wide, Vector3 high, IIcon icon, double res) {
-        Tessellator t = Tessellator.instance;
+        Tessellator tessellator = Tessellator.instance;
 
         double u1 = icon.getMinU();
         double du = icon.getMaxU() - icon.getMinU();
@@ -91,20 +91,25 @@ public class RenderUtils {
                 Vector3 dy1 = vectors[4].set(high).multiply(y / hlen);
                 Vector3 dy2 = vectors[5].set(high).multiply((y + ry) / hlen);
 
-                t.addVertexWithUV(
+                tessellator.addVertexWithUV(
                         base.x + dx1.x + dy2.x,
                         base.y + dx1.y + dy2.y,
                         base.z + dx1.z + dy2.z,
                         u1,
                         v2 - ry / res * dv);
-                t.addVertexWithUV(base.x + dx1.x + dy1.x, base.y + dx1.y + dy1.y, base.z + dx1.z + dy1.z, u1, v2);
-                t.addVertexWithUV(
+                tessellator.addVertexWithUV(
+                        base.x + dx1.x + dy1.x,
+                        base.y + dx1.y + dy1.y,
+                        base.z + dx1.z + dy1.z,
+                        u1,
+                        v2);
+                tessellator.addVertexWithUV(
                         base.x + dx2.x + dy1.x,
                         base.y + dx2.y + dy1.y,
                         base.z + dx2.z + dy1.z,
                         u1 + rx / res * du,
                         v2);
-                t.addVertexWithUV(
+                tessellator.addVertexWithUV(
                         base.x + dx2.x + dy2.x,
                         base.y + dx2.y + dy2.y,
                         base.z + dx2.z + dy2.z,
@@ -126,123 +131,133 @@ public class RenderUtils {
     }
 
     public static void drawCuboidOutline(Cuboid6 c) {
-        Tessellator var2 = Tessellator.instance;
-        var2.startDrawing(3);
-        var2.addVertex(c.min.x, c.min.y, c.min.z);
-        var2.addVertex(c.max.x, c.min.y, c.min.z);
-        var2.addVertex(c.max.x, c.min.y, c.max.z);
-        var2.addVertex(c.min.x, c.min.y, c.max.z);
-        var2.addVertex(c.min.x, c.min.y, c.min.z);
-        var2.draw();
-        var2.startDrawing(3);
-        var2.addVertex(c.min.x, c.max.y, c.min.z);
-        var2.addVertex(c.max.x, c.max.y, c.min.z);
-        var2.addVertex(c.max.x, c.max.y, c.max.z);
-        var2.addVertex(c.min.x, c.max.y, c.max.z);
-        var2.addVertex(c.min.x, c.max.y, c.min.z);
-        var2.draw();
-        var2.startDrawing(1);
-        var2.addVertex(c.min.x, c.min.y, c.min.z);
-        var2.addVertex(c.min.x, c.max.y, c.min.z);
-        var2.addVertex(c.max.x, c.min.y, c.min.z);
-        var2.addVertex(c.max.x, c.max.y, c.min.z);
-        var2.addVertex(c.max.x, c.min.y, c.max.z);
-        var2.addVertex(c.max.x, c.max.y, c.max.z);
-        var2.addVertex(c.min.x, c.min.y, c.max.z);
-        var2.addVertex(c.min.x, c.max.y, c.max.z);
-        var2.draw();
+        Tessellator tess = Tessellator.instance;
+        tess.startDrawing(3);
+        tess.addVertex(c.min.x, c.min.y, c.min.z);
+        tess.addVertex(c.max.x, c.min.y, c.min.z);
+        tess.addVertex(c.max.x, c.min.y, c.max.z);
+        tess.addVertex(c.min.x, c.min.y, c.max.z);
+        tess.addVertex(c.min.x, c.min.y, c.min.z);
+        tess.draw();
+        tess.startDrawing(3);
+        tess.addVertex(c.min.x, c.max.y, c.min.z);
+        tess.addVertex(c.max.x, c.max.y, c.min.z);
+        tess.addVertex(c.max.x, c.max.y, c.max.z);
+        tess.addVertex(c.min.x, c.max.y, c.max.z);
+        tess.addVertex(c.min.x, c.max.y, c.min.z);
+        tess.draw();
+        tess.startDrawing(1);
+        tess.addVertex(c.min.x, c.min.y, c.min.z);
+        tess.addVertex(c.min.x, c.max.y, c.min.z);
+        tess.addVertex(c.max.x, c.min.y, c.min.z);
+        tess.addVertex(c.max.x, c.max.y, c.min.z);
+        tess.addVertex(c.max.x, c.min.y, c.max.z);
+        tess.addVertex(c.max.x, c.max.y, c.max.z);
+        tess.addVertex(c.min.x, c.min.y, c.max.z);
+        tess.addVertex(c.min.x, c.max.y, c.max.z);
+        tess.draw();
     }
 
     public static void renderFluidCuboid(CCRenderState state, Cuboid6 bound, IIcon tex, double res) {
-        renderFluidQuad( // bottom
-                new Vector3(bound.min.x, bound.min.y, bound.min.z),
-                new Vector3(bound.max.x, bound.min.y, bound.min.z),
-                new Vector3(bound.max.x, bound.min.y, bound.max.z),
-                new Vector3(bound.min.x, bound.min.y, bound.max.z),
-                tex,
-                res);
-        renderFluidQuad( // top
-                new Vector3(bound.min.x, bound.max.y, bound.min.z),
-                new Vector3(bound.min.x, bound.max.y, bound.max.z),
-                new Vector3(bound.max.x, bound.max.y, bound.max.z),
-                new Vector3(bound.max.x, bound.max.y, bound.min.z),
-                tex,
-                res);
-        renderFluidQuad( // -x
-                new Vector3(bound.min.x, bound.max.y, bound.min.z),
-                new Vector3(bound.min.x, bound.min.y, bound.min.z),
-                new Vector3(bound.min.x, bound.min.y, bound.max.z),
-                new Vector3(bound.min.x, bound.max.y, bound.max.z),
-                tex,
-                res);
-        renderFluidQuad( // +x
-                new Vector3(bound.max.x, bound.max.y, bound.max.z),
-                new Vector3(bound.max.x, bound.min.y, bound.max.z),
-                new Vector3(bound.max.x, bound.min.y, bound.min.z),
-                new Vector3(bound.max.x, bound.max.y, bound.min.z),
-                tex,
-                res);
-        renderFluidQuad( // -z
-                new Vector3(bound.max.x, bound.max.y, bound.min.z),
-                new Vector3(bound.max.x, bound.min.y, bound.min.z),
-                new Vector3(bound.min.x, bound.min.y, bound.min.z),
-                new Vector3(bound.min.x, bound.max.y, bound.min.z),
-                tex,
-                res);
-        renderFluidQuad( // +z
-                new Vector3(bound.min.x, bound.max.y, bound.max.z),
-                new Vector3(bound.min.x, bound.min.y, bound.max.z),
-                new Vector3(bound.max.x, bound.min.y, bound.max.z),
-                new Vector3(bound.max.x, bound.max.y, bound.max.z),
-                tex,
-                res);
+        renderFluidCuboid(bound, tex, res);
     }
 
     public static void renderFluidCuboid(Cuboid6 bound, IIcon tex, double res) {
-        renderFluidCuboid(CCRenderState.instance(), bound, tex, res);
+        final double minX = bound.min.x;
+        final double minY = bound.min.y;
+        final double minZ = bound.min.z;
+        final double maxX = bound.max.x;
+        final double maxY = bound.max.y;
+        final double maxZ = bound.max.z;
+        renderFluidQuad( // bottom
+                new Vector3(minX, minY, minZ),
+                new Vector3(maxX, minY, minZ),
+                null,
+                new Vector3(minX, minY, maxZ),
+                tex,
+                res);
+        renderFluidQuad( // top
+                new Vector3(minX, maxY, minZ),
+                new Vector3(minX, maxY, maxZ),
+                null,
+                new Vector3(maxX, maxY, minZ),
+                tex,
+                res);
+        renderFluidQuad( // -x
+                new Vector3(minX, maxY, minZ),
+                new Vector3(minX, minY, minZ),
+                null,
+                new Vector3(minX, maxY, maxZ),
+                tex,
+                res);
+        renderFluidQuad( // +x
+                new Vector3(maxX, maxY, maxZ),
+                new Vector3(maxX, minY, maxZ),
+                null,
+                new Vector3(maxX, maxY, minZ),
+                tex,
+                res);
+        renderFluidQuad( // -z
+                new Vector3(maxX, maxY, minZ),
+                new Vector3(maxX, minY, minZ),
+                null,
+                new Vector3(minX, maxY, minZ),
+                tex,
+                res);
+        renderFluidQuad( // +z
+                new Vector3(minX, maxY, maxZ),
+                new Vector3(minX, minY, maxZ),
+                null,
+                new Vector3(maxX, maxY, maxZ),
+                tex,
+                res);
     }
 
     public static void renderBlockOverlaySide(int x, int y, int z, int side, double tx1, double tx2, double ty1,
             double ty2) {
-        double[] points = new double[] { x - 0.009, x + 1.009, y - 0.009, y + 1.009, z - 0.009, z + 1.009 };
-
         Tessellator tessellator = Tessellator.instance;
+        final double minX = x - 0.009;
+        final double maxX = x + 1.009;
+        final double minY = y - 0.009;
+        final double maxY = y + 1.009;
+        final double minZ = z - 0.009;
+        final double maxZ = z + 1.009;
         switch (side) {
             case 0:
-                tessellator.addVertexWithUV(points[0], points[2], points[4], tx1, ty1);
-                tessellator.addVertexWithUV(points[1], points[2], points[4], tx2, ty1);
-                tessellator.addVertexWithUV(points[1], points[2], points[5], tx2, ty2);
-                tessellator.addVertexWithUV(points[0], points[2], points[5], tx1, ty2);
+                tessellator.addVertexWithUV(minX, minY, minZ, tx1, ty1);
+                tessellator.addVertexWithUV(maxX, minY, minZ, tx2, ty1);
+                tessellator.addVertexWithUV(maxX, minY, maxZ, tx2, ty2);
+                tessellator.addVertexWithUV(minX, minY, maxZ, tx1, ty2);
                 break;
             case 1:
-                tessellator.addVertexWithUV(points[1], points[3], points[4], tx2, ty1);
-                tessellator.addVertexWithUV(points[0], points[3], points[4], tx1, ty1);
-                tessellator.addVertexWithUV(points[0], points[3], points[5], tx1, ty2);
-                tessellator.addVertexWithUV(points[1], points[3], points[5], tx2, ty2);
+                tessellator.addVertexWithUV(maxX, maxY, minZ, tx2, ty1);
+                tessellator.addVertexWithUV(minX, maxY, minZ, tx1, ty1);
+                tessellator.addVertexWithUV(minX, maxY, maxZ, tx1, ty2);
+                tessellator.addVertexWithUV(maxX, maxY, maxZ, tx2, ty2);
                 break;
             case 2:
-                tessellator.addVertexWithUV(points[0], points[3], points[4], tx2, ty1);
-                tessellator.addVertexWithUV(points[1], points[3], points[4], tx1, ty1);
-                tessellator.addVertexWithUV(points[1], points[2], points[4], tx1, ty2);
-                tessellator.addVertexWithUV(points[0], points[2], points[4], tx2, ty2);
+                tessellator.addVertexWithUV(minX, maxY, minZ, tx2, ty1);
+                tessellator.addVertexWithUV(maxX, maxY, minZ, tx1, ty1);
+                tessellator.addVertexWithUV(maxX, minY, minZ, tx1, ty2);
+                tessellator.addVertexWithUV(minX, minY, minZ, tx2, ty2);
                 break;
             case 3:
-                tessellator.addVertexWithUV(points[1], points[3], points[5], tx2, ty1);
-                tessellator.addVertexWithUV(points[0], points[3], points[5], tx1, ty1);
-                tessellator.addVertexWithUV(points[0], points[2], points[5], tx1, ty2);
-                tessellator.addVertexWithUV(points[1], points[2], points[5], tx2, ty2);
+                tessellator.addVertexWithUV(maxX, maxY, maxZ, tx2, ty1);
+                tessellator.addVertexWithUV(minX, maxY, maxZ, tx1, ty1);
+                tessellator.addVertexWithUV(minX, minY, maxZ, tx1, ty2);
+                tessellator.addVertexWithUV(maxX, minY, maxZ, tx2, ty2);
                 break;
             case 4:
-                tessellator.addVertexWithUV(points[0], points[3], points[5], tx2, ty1);
-                tessellator.addVertexWithUV(points[0], points[3], points[4], tx1, ty1);
-                tessellator.addVertexWithUV(points[0], points[2], points[4], tx1, ty2);
-                tessellator.addVertexWithUV(points[0], points[2], points[5], tx2, ty2);
+                tessellator.addVertexWithUV(minX, maxY, maxZ, tx2, ty1);
+                tessellator.addVertexWithUV(minX, maxY, minZ, tx1, ty1);
+                tessellator.addVertexWithUV(minX, minY, minZ, tx1, ty2);
+                tessellator.addVertexWithUV(minX, minY, maxZ, tx2, ty2);
                 break;
             case 5:
-                tessellator.addVertexWithUV(points[1], points[3], points[4], tx2, ty1);
-                tessellator.addVertexWithUV(points[1], points[3], points[5], tx1, ty1);
-                tessellator.addVertexWithUV(points[1], points[2], points[5], tx1, ty2);
-                tessellator.addVertexWithUV(points[1], points[2], points[4], tx2, ty2);
+                tessellator.addVertexWithUV(maxX, maxY, minZ, tx2, ty1);
+                tessellator.addVertexWithUV(maxX, maxY, maxZ, tx1, ty1);
+                tessellator.addVertexWithUV(maxX, minY, maxZ, tx1, ty2);
+                tessellator.addVertexWithUV(maxX, minY, minZ, tx2, ty2);
                 break;
         }
     }
@@ -306,7 +321,7 @@ public class RenderUtils {
 
         IIcon tex = prepareFluidRender(state, stack, alpha);
         state.startDrawingInstance();
-        renderFluidCuboid(state, bound, tex, res);
+        renderFluidCuboid(bound, tex, res);
         state.drawInstance();
         postFluidRender();
     }

--- a/src/main/java/codechicken/lib/render/RenderUtils.java
+++ b/src/main/java/codechicken/lib/render/RenderUtils.java
@@ -27,20 +27,22 @@ import codechicken.lib.vec.Vector3;
 
 public class RenderUtils {
 
-    static Vector3[] vectors = new Vector3[8];
-    static RenderItem uniformRenderItem = new RenderItem() {
-
-        public boolean shouldBob() {
-            return false;
-        }
-    };
+    static Vector3[] vectors;
+    static RenderItem uniformRenderItem;
     static EntityItem entityItem;
 
     static {
-        for (int i = 0; i < vectors.length; i++) vectors[i] = new Vector3();
+        vectors = new Vector3[8];
+        for (int i = 0; i < vectors.length; i++) {
+            vectors[i] = new Vector3();
+        }
+        uniformRenderItem = new RenderItem() {
 
+            public boolean shouldBob() {
+                return false;
+            }
+        };
         uniformRenderItem.setRenderManager(RenderManager.instance);
-
         entityItem = new EntityItem(null);
         entityItem.hoverStart = 0;
     }

--- a/src/main/java/codechicken/lib/render/RenderUtils.java
+++ b/src/main/java/codechicken/lib/render/RenderUtils.java
@@ -68,53 +68,53 @@ public class RenderUtils {
     public static void renderFluidQuad(Vector3 base, Vector3 wide, Vector3 high, IIcon icon, double res) {
         Tessellator tessellator = Tessellator.instance;
 
-        double u1 = icon.getMinU();
+        double u = icon.getMinU();
         double du = icon.getMaxU() - icon.getMinU();
-        double v2 = icon.getMaxV();
+        double v = icon.getMinV();
         double dv = icon.getMaxV() - icon.getMinV();
 
-        double wlen = wide.mag();
-        double hlen = high.mag();
+        double wideLen = wide.mag();
+        double highLen = high.mag();
 
         double x = 0;
-        while (x < wlen) {
-            double rx = wlen - x;
+        while (x < wideLen) {
+            double rx = wideLen - x;
             if (rx > res) rx = res;
 
             double y = 0;
-            while (y < hlen) {
-                double ry = hlen - y;
+            while (y < highLen) {
+                double ry = highLen - y;
                 if (ry > res) ry = res;
 
-                Vector3 dx1 = vectors[2].set(wide).multiply(x / wlen);
-                Vector3 dx2 = vectors[3].set(wide).multiply((x + rx) / wlen);
-                Vector3 dy1 = vectors[4].set(high).multiply(y / hlen);
-                Vector3 dy2 = vectors[5].set(high).multiply((y + ry) / hlen);
+                Vector3 dx1 = vectors[2].set(wide).multiply(x / wideLen);
+                Vector3 dx2 = vectors[3].set(wide).multiply((x + rx) / wideLen);
+                Vector3 dy1 = vectors[4].set(high).multiply(y / highLen);
+                Vector3 dy2 = vectors[5].set(high).multiply((y + ry) / highLen);
 
                 tessellator.addVertexWithUV(
                         base.x + dx1.x + dy2.x,
                         base.y + dx1.y + dy2.y,
                         base.z + dx1.z + dy2.z,
-                        u1,
-                        v2 - ry / res * dv);
+                        u,
+                        v + ry / res * dv);
                 tessellator.addVertexWithUV(
                         base.x + dx1.x + dy1.x,
                         base.y + dx1.y + dy1.y,
                         base.z + dx1.z + dy1.z,
-                        u1,
-                        v2);
+                        u,
+                        v);
                 tessellator.addVertexWithUV(
                         base.x + dx2.x + dy1.x,
                         base.y + dx2.y + dy1.y,
                         base.z + dx2.z + dy1.z,
-                        u1 + rx / res * du,
-                        v2);
+                        u + rx / res * du,
+                        v);
                 tessellator.addVertexWithUV(
                         base.x + dx2.x + dy2.x,
                         base.y + dx2.y + dy2.y,
                         base.z + dx2.z + dy2.z,
-                        u1 + rx / res * du,
-                        v2 - ry / res * dv);
+                        u + rx / res * du,
+                        v + ry / res * dv);
 
                 y += ry;
             }

--- a/src/main/java/codechicken/lib/vec/Matrix4.java
+++ b/src/main/java/codechicken/lib/vec/Matrix4.java
@@ -19,7 +19,10 @@ public class Matrix4 extends Transformation implements Copyable<Matrix4> {
             .asDoubleBuffer();
 
     // m<row><column>
-    public double m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33;
+    public double m00, m01, m02, m03;
+    public double m10, m11, m12, m13;
+    public double m20, m21, m22, m23;
+    public double m30, m31, m32, m33;
 
     public Matrix4() {
         m00 = m11 = m22 = m33 = 1;
@@ -65,6 +68,15 @@ public class Matrix4 extends Transformation implements Copyable<Matrix4> {
         return this;
     }
 
+    public Matrix4 translate(double x, double y, double z) {
+        m03 += m00 * x + m01 * y + m02 * z;
+        m13 += m10 * x + m11 * y + m12 * z;
+        m23 += m20 * x + m21 * y + m22 * z;
+        m33 += m30 * x + m31 * y + m32 * z;
+
+        return this;
+    }
+
     public Matrix4 scale(Vector3 vec) {
         m00 *= vec.x;
         m10 *= vec.x;
@@ -79,6 +91,22 @@ public class Matrix4 extends Transformation implements Copyable<Matrix4> {
         m22 *= vec.z;
         m32 *= vec.z;
 
+        return this;
+    }
+
+    public Matrix4 scale(double scale) {
+        m00 *= scale;
+        m10 *= scale;
+        m20 *= scale;
+        m30 *= scale;
+        m01 *= scale;
+        m11 *= scale;
+        m21 *= scale;
+        m31 *= scale;
+        m02 *= scale;
+        m12 *= scale;
+        m22 *= scale;
+        m32 *= scale;
         return this;
     }
 

--- a/src/main/java/codechicken/lib/vec/Vector3.java
+++ b/src/main/java/codechicken/lib/vec/Vector3.java
@@ -29,10 +29,10 @@ public class Vector3 implements Copyable<Vector3> {
 
     public Vector3() {}
 
-    public Vector3(double d, double d1, double d2) {
-        x = d;
-        y = d1;
-        z = d2;
+    public Vector3(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     public Vector3(Vector3 vec) {
@@ -398,7 +398,7 @@ public class Vector3 implements Copyable<Vector3> {
 
     /**
      * Equals method with tolerance
-     * 
+     *
      * @return true if this is equal to v within +-1E-5
      */
     public boolean equalsT(Vector3 v) {


### PR DESCRIPTION
Replaces all object instantiation when rendering fluids in world to minimize RAM allocation and work with double x, y ,z coordinates directly

The changes are backward compatible and keeps the old method signatures and redirects to the new ones

Works as intended : 
![2024-10-06_11 50 48](https://github.com/user-attachments/assets/2da9d7ea-2339-4a2c-875d-014c15b1b5cb)