### PR TITLE
use ZipFile instead of ZipInputStream in ClassDiscoverer

### DIFF
--- a/src/main/java/codechicken/core/ClassDiscoverer.java
+++ b/src/main/java/codechicken/core/ClassDiscoverer.java
@@ -1,13 +1,13 @@
 package codechicken.core;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
 
 import net.minecraft.launchwrapper.Launch;
 
@@ -114,21 +114,18 @@ public class ClassDiscoverer {
     }
 
     private void readFromZipFile(File file) throws IOException {
-        FileInputStream fileinputstream = new FileInputStream(file);
-        ZipInputStream zipinputstream = new ZipInputStream(fileinputstream);
-        do {
-            ZipEntry zipentry = zipinputstream.getNextEntry();
-            if (zipentry == null) {
-                break;
-            }
+        ZipFile zipFile = new ZipFile(file);
+        Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+        while (zipEntries.hasMoreElements()) {
+            ZipEntry zipentry = zipEntries.nextElement();
             String fullname = zipentry.getName().replace('\\', '/');
             int pos = fullname.lastIndexOf('/');
             String name = pos == -1 ? fullname : fullname.substring(pos + 1);
             if (!zipentry.isDirectory() && matcher.matches(name)) {
                 checkAddClass(fullname);
             }
-        } while (true);
-        fileinputstream.close();
+        }
+        zipFile.close();
     }
 
     private void readFromDirectory(File directory, File basedirectory) {


### PR DESCRIPTION
Looping through the entire zip file with a ZipInputStream is very slow when all we are using is file names, use ZipFile instead to only read the zip index.

before: `_root > Loading > LoadComplete > NotEnoughItems    3.945991(s)`
after: `_root > Loading > LoadComplete > NotEnoughItems    0.459079(s)`