### PR TITLE
Added color override helper

### DIFF
--- a/src/main/java/codechicken/core/ClientUtils.java
+++ b/src/main/java/codechicken/core/ClientUtils.java
@@ -2,12 +2,16 @@ package codechicken.core;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 import codechicken.core.internal.CCCEventHandler;
+import codechicken.lib.colour.Colour.LocalizedColours;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.relauncher.Side;
@@ -64,5 +68,18 @@ public class ClientUtils extends CommonUtils {
         mc.getMetadata().description = mc.getMetadata().description
                 .replace("Supporters:", EnumChatFormatting.AQUA + "Supporters:");
         GuiModListScroll.register(mod);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void registerLocalizedColourReloadListener() {
+        ((IReloadableResourceManager) mc().getResourceManager())
+                .registerReloadListener(new IResourceManagerReloadListener() {
+
+                    @Override
+                    public void onResourceManagerReload(IResourceManager resourceManager) {
+                        LocalizedColours.reloadLocalizedColours();
+                    }
+                });
+        LocalizedColours.reloadLocalizedColours();
     }
 }

--- a/src/main/java/codechicken/core/ClientUtils.java
+++ b/src/main/java/codechicken/core/ClientUtils.java
@@ -11,7 +11,7 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 import codechicken.core.internal.CCCEventHandler;
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.relauncher.Side;
@@ -80,6 +80,5 @@ public class ClientUtils extends CommonUtils {
                         LocalizedColours.reloadLocalizedColours();
                     }
                 });
-        LocalizedColours.reloadLocalizedColours();
     }
 }

--- a/src/main/java/codechicken/core/GuiModListScroll.java
+++ b/src/main/java/codechicken/core/GuiModListScroll.java
@@ -36,6 +36,7 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import codechicken.core.launch.CodeChickenCorePlugin;
+import codechicken.lib.colour.Colour.Localized;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.lib.vec.Rectangle4i;
 import cpw.mods.fml.client.GuiModList;
@@ -148,10 +149,20 @@ public class GuiModListScroll {
         double dy = scroll % (height + 20);
         GL11.glPushMatrix();
         GL11.glTranslated(0, -dy, 0);
-        GuiDraw.fontRenderer.drawSplitString(description, x1, y1draw, x2 - x1, 0xDDDDDD);
+        GuiDraw.fontRenderer.drawSplitString(
+                description,
+                x1,
+                y1draw,
+                x2 - x1,
+                Localized.getLocalizedColor("modDescriptionText", 0xDDDDDD));
         if (needsScroll) {
             GL11.glTranslated(0, height + 20, 0);
-            GuiDraw.fontRenderer.drawSplitString(description, x1, y1draw, x2 - x1, 0xDDDDDD);
+            GuiDraw.fontRenderer.drawSplitString(
+                    description,
+                    x1,
+                    y1draw,
+                    x2 - x1,
+                    Localized.getLocalizedColor("modDescriptionText", 0xDDDDDD));
         }
         GL11.glPopMatrix();
 

--- a/src/main/java/codechicken/core/GuiModListScroll.java
+++ b/src/main/java/codechicken/core/GuiModListScroll.java
@@ -36,7 +36,7 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import codechicken.core.launch.CodeChickenCorePlugin;
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.lib.vec.Rectangle4i;
 import cpw.mods.fml.client.GuiModList;

--- a/src/main/java/codechicken/core/GuiModListScroll.java
+++ b/src/main/java/codechicken/core/GuiModListScroll.java
@@ -36,7 +36,7 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import codechicken.core.launch.CodeChickenCorePlugin;
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.lib.vec.Rectangle4i;
 import cpw.mods.fml.client.GuiModList;
@@ -149,20 +149,11 @@ public class GuiModListScroll {
         double dy = scroll % (height + 20);
         GL11.glPushMatrix();
         GL11.glTranslated(0, -dy, 0);
-        GuiDraw.fontRenderer.drawSplitString(
-                description,
-                x1,
-                y1draw,
-                x2 - x1,
-                Localized.getLocalizedColor("modDescriptionText", 0xDDDDDD));
+        GuiDraw.fontRenderer.drawSplitString(description, x1, y1draw, x2 - x1, LocalizedColours.MOD_DESCRIPTION_TEXT);
         if (needsScroll) {
             GL11.glTranslated(0, height + 20, 0);
-            GuiDraw.fontRenderer.drawSplitString(
-                    description,
-                    x1,
-                    y1draw,
-                    x2 - x1,
-                    Localized.getLocalizedColor("modDescriptionText", 0xDDDDDD));
+            GuiDraw.fontRenderer
+                    .drawSplitString(description, x1, y1draw, x2 - x1, LocalizedColours.MOD_DESCRIPTION_TEXT);
         }
         GL11.glPopMatrix();
 

--- a/src/main/java/codechicken/core/asm/CodeChickenCoreModContainer.java
+++ b/src/main/java/codechicken/core/asm/CodeChickenCoreModContainer.java
@@ -3,6 +3,10 @@ package codechicken.core.asm;
 import java.util.LinkedList;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraftforge.common.MinecraftForge;
 
 import com.google.common.eventbus.EventBus;
@@ -12,6 +16,7 @@ import codechicken.core.ClientUtils;
 import codechicken.core.featurehack.LiquidTextures;
 import codechicken.core.internal.CCCEventHandler;
 import codechicken.core.launch.CodeChickenCorePlugin;
+import codechicken.lib.colour.Colour.LocalizedColours;
 import cpw.mods.fml.common.DummyModContainer;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.LoadController;
@@ -65,6 +70,15 @@ public class CodeChickenCoreModContainer extends DummyModContainer {
     public void init(FMLInitializationEvent event) {
         if (event.getSide().isClient()) {
             ClientUtils.enhanceSupportersList("CodeChickenCore");
+            ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
+                    .registerReloadListener(new IResourceManagerReloadListener() {
+
+                        @Override
+                        public void onResourceManagerReload(IResourceManager resourceManager) {
+                            LocalizedColours.reloadLocalizedColours();
+                        }
+                    });
+            LocalizedColours.reloadLocalizedColours();
 
             FMLCommonHandler.instance().bus().register(new CCCEventHandler());
             MinecraftForge.EVENT_BUS.register(new CCCEventHandler());

--- a/src/main/java/codechicken/core/asm/CodeChickenCoreModContainer.java
+++ b/src/main/java/codechicken/core/asm/CodeChickenCoreModContainer.java
@@ -3,10 +3,6 @@ package codechicken.core.asm;
 import java.util.LinkedList;
 import java.util.List;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.IReloadableResourceManager;
-import net.minecraft.client.resources.IResourceManager;
-import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraftforge.common.MinecraftForge;
 
 import com.google.common.eventbus.EventBus;
@@ -16,7 +12,6 @@ import codechicken.core.ClientUtils;
 import codechicken.core.featurehack.LiquidTextures;
 import codechicken.core.internal.CCCEventHandler;
 import codechicken.core.launch.CodeChickenCorePlugin;
-import codechicken.lib.colour.Colour.LocalizedColours;
 import cpw.mods.fml.common.DummyModContainer;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.LoadController;
@@ -70,15 +65,7 @@ public class CodeChickenCoreModContainer extends DummyModContainer {
     public void init(FMLInitializationEvent event) {
         if (event.getSide().isClient()) {
             ClientUtils.enhanceSupportersList("CodeChickenCore");
-            ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
-                    .registerReloadListener(new IResourceManagerReloadListener() {
-
-                        @Override
-                        public void onResourceManagerReload(IResourceManager resourceManager) {
-                            LocalizedColours.reloadLocalizedColours();
-                        }
-                    });
-            LocalizedColours.reloadLocalizedColours();
+            ClientUtils.registerLocalizedColourReloadListener();
 
             FMLCommonHandler.instance().bus().register(new CCCEventHandler());
             MinecraftForge.EVENT_BUS.register(new CCCEventHandler());

--- a/src/main/java/codechicken/core/gui/GuiCCButton.java
+++ b/src/main/java/codechicken/core/gui/GuiCCButton.java
@@ -6,7 +6,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 
 public class GuiCCButton extends GuiWidget {
 

--- a/src/main/java/codechicken/core/gui/GuiCCButton.java
+++ b/src/main/java/codechicken/core/gui/GuiCCButton.java
@@ -6,6 +6,8 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.lib.colour.Colour.Localized;
+
 public class GuiCCButton extends GuiWidget {
 
     public String text;
@@ -73,7 +75,9 @@ public class GuiCCButton extends GuiWidget {
     }
 
     public int getTextColour(int mousex, int mousey) {
-        return !isEnabled ? 0xFFA0A0A0 : pointInside(mousex, mousey) ? 0xFFFFFFA0 : 0xFFE0E0E0;
+        return !isEnabled ? Localized.getLocalizedColor("buttonTextDisabled", 0xFFA0A0A0)
+                : pointInside(mousex, mousey) ? Localized.getLocalizedColor("buttonTextHover", 0xFFFFFFA0)
+                        : Localized.getLocalizedColor("buttonText", 0xFFE0E0E0);
     }
 
     public GuiCCButton setActionCommand(String string) {

--- a/src/main/java/codechicken/core/gui/GuiCCButton.java
+++ b/src/main/java/codechicken/core/gui/GuiCCButton.java
@@ -6,7 +6,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 
 public class GuiCCButton extends GuiWidget {
 
@@ -75,9 +75,8 @@ public class GuiCCButton extends GuiWidget {
     }
 
     public int getTextColour(int mousex, int mousey) {
-        return !isEnabled ? Localized.getLocalizedColor("buttonTextDisabled", 0xFFA0A0A0)
-                : pointInside(mousex, mousey) ? Localized.getLocalizedColor("buttonTextHover", 0xFFFFFFA0)
-                        : Localized.getLocalizedColor("buttonText", 0xFFE0E0E0);
+        return !isEnabled ? LocalizedColours.BUTTON_TEXT_DISABLED
+                : pointInside(mousex, mousey) ? LocalizedColours.BUTTON_TEXT_HOVER : LocalizedColours.BUTTON_TEXT;
     }
 
     public GuiCCButton setActionCommand(String string) {

--- a/src/main/java/codechicken/core/gui/GuiCCTextField.java
+++ b/src/main/java/codechicken/core/gui/GuiCCTextField.java
@@ -5,7 +5,7 @@ import net.minecraft.util.ChatAllowedCharacters;
 
 import org.lwjgl.input.Keyboard;
 
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 
 public class GuiCCTextField extends GuiWidget {
 
@@ -122,13 +122,8 @@ public class GuiCCTextField extends GuiWidget {
     }
 
     public void drawBackground() {
-        drawRect(
-                x - 1,
-                y - 1,
-                x + width + 1,
-                y + height + 1,
-                Localized.getLocalizedColor("textFieldBorder", 0xFFA0A0A0));
-        drawRect(x, y, x + width, y + height, Localized.getLocalizedColor("textFieldBackground", 0xFF000000));
+        drawRect(x - 1, y - 1, x + width + 1, y + height + 1, LocalizedColours.TEXT_FIELD_BORDER);
+        drawRect(x, y, x + width, y + height, LocalizedColours.TEXT_FIELD_BACKGROUND);
     }
 
     public String getDrawText() {
@@ -142,8 +137,7 @@ public class GuiCCTextField extends GuiWidget {
     }
 
     public int getTextColour() {
-        return isEnabled ? Localized.getLocalizedColor("textFieldText", 0xE0E0E0)
-                : Localized.getLocalizedColor("textFieldTextDisabled", 0x707070);
+        return isEnabled ? LocalizedColours.TEXT_FIELD_TEXT : LocalizedColours.TEXT_FIELD_TEXT_DISABLED;
     }
 
     public GuiCCTextField setMaxStringLength(int i) {

--- a/src/main/java/codechicken/core/gui/GuiCCTextField.java
+++ b/src/main/java/codechicken/core/gui/GuiCCTextField.java
@@ -5,7 +5,7 @@ import net.minecraft.util.ChatAllowedCharacters;
 
 import org.lwjgl.input.Keyboard;
 
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 
 public class GuiCCTextField extends GuiWidget {
 

--- a/src/main/java/codechicken/core/gui/GuiCCTextField.java
+++ b/src/main/java/codechicken/core/gui/GuiCCTextField.java
@@ -5,6 +5,8 @@ import net.minecraft.util.ChatAllowedCharacters;
 
 import org.lwjgl.input.Keyboard;
 
+import codechicken.lib.colour.Colour.Localized;
+
 public class GuiCCTextField extends GuiWidget {
 
     private String text;
@@ -120,8 +122,13 @@ public class GuiCCTextField extends GuiWidget {
     }
 
     public void drawBackground() {
-        drawRect(x - 1, y - 1, x + width + 1, y + height + 1, 0xffa0a0a0);
-        drawRect(x, y, x + width, y + height, 0xff000000);
+        drawRect(
+                x - 1,
+                y - 1,
+                x + width + 1,
+                y + height + 1,
+                Localized.getLocalizedColor("textFieldBorder", 0xFFA0A0A0));
+        drawRect(x, y, x + width, y + height, Localized.getLocalizedColor("textFieldBackground", 0xFF000000));
     }
 
     public String getDrawText() {
@@ -135,7 +142,8 @@ public class GuiCCTextField extends GuiWidget {
     }
 
     public int getTextColour() {
-        return isEnabled ? 0xe0e0e0 : 0x707070;
+        return isEnabled ? Localized.getLocalizedColor("textFieldText", 0xE0E0E0)
+                : Localized.getLocalizedColor("textFieldTextDisabled", 0x707070);
     }
 
     public GuiCCTextField setMaxStringLength(int i) {

--- a/src/main/java/codechicken/core/gui/GuiScrollPane.java
+++ b/src/main/java/codechicken/core/gui/GuiScrollPane.java
@@ -3,7 +3,7 @@ package codechicken.core.gui;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.vec.Rectangle4i;
 
@@ -185,53 +185,29 @@ public abstract class GuiScrollPane extends GuiWidget {
     }
 
     public void drawBackground(float frame) {
-        drawRect(x, y, x + width, y + height, Localized.getLocalizedColor("background", 0xFF000000));
+        drawRect(x, y, x + width, y + height, LocalizedColours.SCROLL_PANE_BACKGROUND);
     }
 
     public abstract void drawContent(int mx, int my, float frame);
 
     public void drawOverlay(float frame) {
         // outlines
-        drawRect(x, y - 1, x + width, y, Localized.getLocalizedColor("overlayTop", 0xFFA0A0A0));
-        drawRect(x, y + height, x + width, y + height + 1, Localized.getLocalizedColor("overlayBottom", 0xFFA0A0A0));
-        drawRect(x - 1, y - 1, x, y + height + 1, Localized.getLocalizedColor("overlayLeft", 0xFFA0A0A0));
-        drawRect(
-                x + width,
-                y - 1,
-                x + width + 1,
-                y + height + 1,
-                Localized.getLocalizedColor("overlayRight", 0xFFA0A0A0));
+        drawRect(x, y - 1, x + width, y, LocalizedColours.SCROLL_PANE_OVERLAY_TOP);
+        drawRect(x, y + height, x + width, y + height + 1, LocalizedColours.SCROLL_PANE_OVERLAY_BOTTOM);
+        drawRect(x - 1, y - 1, x, y + height + 1, LocalizedColours.SCROLL_PANE_OVERLAY_LEFT);
+        drawRect(x + width, y - 1, x + width + 1, y + height + 1, LocalizedColours.SCROLL_PANE_OVERLAY_RIGHT);
     }
 
     public void drawScrollbar(float frame) {
         Rectangle r = scrollbarBounds();
 
-        drawRect(r.x, r.y, r.x + r.width, r.y + r.height, Localized.getLocalizedColor("scrollbarCorners", 0xFF8B8B8B));
-        drawRect(
-                r.x,
-                r.y,
-                r.x + r.width - 1,
-                r.y + r.height - 1,
-                Localized.getLocalizedColor("scrollbarTopLeft", 0xFFF0F0F0));
-        drawRect(
-                r.x + 1,
-                r.y + 1,
-                r.x + r.width,
-                r.y + r.height,
-                Localized.getLocalizedColor("scrollbarBottomRight", 0xFF555555));
-        drawRect(
-                r.x + 1,
-                r.y + 1,
-                r.x + r.width - 1,
-                r.y + r.height - 1,
-                Localized.getLocalizedColor("scrollbarFill", 0xFFC6C6C6));
+        drawRect(r.x, r.y, r.x + r.width, r.y + r.height, LocalizedColours.SCROLLBAR_CORNERS);
+        drawRect(r.x, r.y, r.x + r.width - 1, r.y + r.height - 1, LocalizedColours.SCROLLBAR_TOP_LEFT);
+        drawRect(r.x + 1, r.y + 1, r.x + r.width, r.y + r.height, LocalizedColours.SCROLLBAR_BOTTOM_RIGHT);
+        drawRect(r.x + 1, r.y + 1, r.x + r.width - 1, r.y + r.height - 1, LocalizedColours.SCROLLBAR_FILL);
 
         int algn = scrollbarGuideAlignment();
-        if (algn != 0) drawRect(
-                algn > 0 ? r.x + r.width : r.x - 1,
-                y,
-                r.x,
-                y + height,
-                Localized.getLocalizedColor("scrollbarGuide", 0xFF808080));
+        if (algn != 0)
+            drawRect(algn > 0 ? r.x + r.width : r.x - 1, y, r.x, y + height, LocalizedColours.SCROLLBAR_GUIDE);
     }
 }

--- a/src/main/java/codechicken/core/gui/GuiScrollPane.java
+++ b/src/main/java/codechicken/core/gui/GuiScrollPane.java
@@ -3,6 +3,7 @@ package codechicken.core.gui;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 
+import codechicken.lib.colour.Colour.Localized;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.vec.Rectangle4i;
 
@@ -184,28 +185,53 @@ public abstract class GuiScrollPane extends GuiWidget {
     }
 
     public void drawBackground(float frame) {
-        drawRect(x, y, x + width, y + height, 0xff000000);
+        drawRect(x, y, x + width, y + height, Localized.getLocalizedColor("background", 0xFF000000));
     }
 
     public abstract void drawContent(int mx, int my, float frame);
 
     public void drawOverlay(float frame) {
         // outlines
-        drawRect(x, y - 1, x + width, y, 0xffa0a0a0); // top
-        drawRect(x, y + height, x + width, y + height + 1, 0xffa0a0a0); // bottom
-        drawRect(x - 1, y - 1, x, y + height + 1, 0xffa0a0a0); // left
-        drawRect(x + width, y - 1, x + width + 1, y + height + 1, 0xffa0a0a0); // right
+        drawRect(x, y - 1, x + width, y, Localized.getLocalizedColor("overlayTop", 0xFFA0A0A0));
+        drawRect(x, y + height, x + width, y + height + 1, Localized.getLocalizedColor("overlayBottom", 0xFFA0A0A0));
+        drawRect(x - 1, y - 1, x, y + height + 1, Localized.getLocalizedColor("overlayLeft", 0xFFA0A0A0));
+        drawRect(
+                x + width,
+                y - 1,
+                x + width + 1,
+                y + height + 1,
+                Localized.getLocalizedColor("overlayRight", 0xFFA0A0A0));
     }
 
     public void drawScrollbar(float frame) {
         Rectangle r = scrollbarBounds();
 
-        drawRect(r.x, r.y, r.x + r.width, r.y + r.height, 0xFF8B8B8B); // corners
-        drawRect(r.x, r.y, r.x + r.width - 1, r.y + r.height - 1, 0xFFF0F0F0); // topleft up
-        drawRect(r.x + 1, r.y + 1, r.x + r.width, r.y + r.height, 0xFF555555); // bottom right down
-        drawRect(r.x + 1, r.y + 1, r.x + r.width - 1, r.y + r.height - 1, 0xFFC6C6C6); // scrollbar
+        drawRect(r.x, r.y, r.x + r.width, r.y + r.height, Localized.getLocalizedColor("scrollbarCorners", 0xFF8B8B8B));
+        drawRect(
+                r.x,
+                r.y,
+                r.x + r.width - 1,
+                r.y + r.height - 1,
+                Localized.getLocalizedColor("scrollbarTopLeft", 0xFFF0F0F0));
+        drawRect(
+                r.x + 1,
+                r.y + 1,
+                r.x + r.width,
+                r.y + r.height,
+                Localized.getLocalizedColor("scrollbarBottomRight", 0xFF555555));
+        drawRect(
+                r.x + 1,
+                r.y + 1,
+                r.x + r.width - 1,
+                r.y + r.height - 1,
+                Localized.getLocalizedColor("scrollbarFill", 0xFFC6C6C6));
 
         int algn = scrollbarGuideAlignment();
-        if (algn != 0) drawRect(algn > 0 ? r.x + r.width : r.x - 1, y, r.x, y + height, 0xFF808080); // lineguide
+        if (algn != 0) drawRect(
+                algn > 0 ? r.x + r.width : r.x - 1,
+                y,
+                r.x,
+                y + height,
+                Localized.getLocalizedColor("scrollbarGuide", 0xFF808080));
     }
 }

--- a/src/main/java/codechicken/core/gui/GuiScrollPane.java
+++ b/src/main/java/codechicken/core/gui/GuiScrollPane.java
@@ -3,7 +3,7 @@ package codechicken.core.gui;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.vec.Rectangle4i;
 

--- a/src/main/java/codechicken/lib/colour/Colour.java
+++ b/src/main/java/codechicken/lib/colour/Colour.java
@@ -3,6 +3,8 @@ package codechicken.lib.colour;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.minecraft.util.StatCollector;
+
 import org.lwjgl.opengl.GL11;
 
 import codechicken.lib.config.ConfigTag.IConfigType;
@@ -12,6 +14,42 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class Colour implements Copyable<Colour> {
+
+    public static final class Localized {
+
+        private static final String KEY_PREFIX = "codechickencore.color.";
+
+        private Localized() {}
+
+        /**
+         * Resolve a optional localized ARGB color from lang files. Expected value format: AARRGGBB (for example
+         * FF555555).
+         */
+        public static int getLocalizedColor(String key, int defaultColor) {
+            String fullKey = KEY_PREFIX + key;
+            if (!StatCollector.canTranslate(fullKey)) {
+                return defaultColor;
+            }
+
+            String raw = StatCollector.translateToLocal(fullKey);
+            if (raw == null) {
+                return defaultColor;
+            }
+
+            String hex = raw.trim();
+            if (hex.startsWith("0x") || hex.startsWith("0X")) {
+                hex = hex.substring(2);
+            } else if (hex.startsWith("#")) {
+                hex = hex.substring(1);
+            }
+
+            try {
+                return (int) Long.parseLong(hex, 16);
+            } catch (NumberFormatException ignored) {
+                return defaultColor;
+            }
+        }
+    }
 
     public static IConfigType<Colour> configRGB = new IConfigType<Colour>() {
 

--- a/src/main/java/codechicken/lib/colour/Colour.java
+++ b/src/main/java/codechicken/lib/colour/Colour.java
@@ -15,11 +15,63 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class Colour implements Copyable<Colour> {
 
-    public static final class Localized {
+    public static final class LocalizedColours {
 
         private static final String KEY_PREFIX = "codechickencore.color.";
 
-        private Localized() {}
+        public static int BUTTON_TEXT_DISABLED;
+        public static int BUTTON_TEXT_HOVER;
+        public static int BUTTON_TEXT;
+        public static int TEXT_FIELD_BORDER;
+        public static int TEXT_FIELD_BACKGROUND;
+        public static int TEXT_FIELD_TEXT;
+        public static int TEXT_FIELD_TEXT_DISABLED;
+        public static int SCROLL_PANE_BACKGROUND;
+        public static int SCROLL_PANE_OVERLAY_TOP;
+        public static int SCROLL_PANE_OVERLAY_BOTTOM;
+        public static int SCROLL_PANE_OVERLAY_LEFT;
+        public static int SCROLL_PANE_OVERLAY_RIGHT;
+        public static int SCROLLBAR_CORNERS;
+        public static int SCROLLBAR_TOP_LEFT;
+        public static int SCROLLBAR_BOTTOM_RIGHT;
+        public static int SCROLLBAR_FILL;
+        public static int SCROLLBAR_GUIDE;
+        public static int TOOLTIP_BG_START;
+        public static int TOOLTIP_BG_END;
+        public static int TOOLTIP_BORDER_START;
+        public static int TOOLTIP_BORDER_END;
+        public static int TOOLTIP_TEXT;
+        public static int ITEM_QUANTITY_TEXT;
+        public static int MOD_DESCRIPTION_TEXT;
+
+        private LocalizedColours() {}
+
+        public static void reloadLocalizedColours() {
+            BUTTON_TEXT_DISABLED = getLocalizedColor("buttonTextDisabled", 0xFFA0A0A0);
+            BUTTON_TEXT_HOVER = getLocalizedColor("buttonTextHover", 0xFFFFFFA0);
+            BUTTON_TEXT = getLocalizedColor("buttonText", 0xFFE0E0E0);
+            TEXT_FIELD_BORDER = getLocalizedColor("textFieldBorder", 0xFFA0A0A0);
+            TEXT_FIELD_BACKGROUND = getLocalizedColor("textFieldBackground", 0xFF000000);
+            TEXT_FIELD_TEXT = getLocalizedColor("textFieldText", 0xE0E0E0);
+            TEXT_FIELD_TEXT_DISABLED = getLocalizedColor("textFieldTextDisabled", 0x707070);
+            SCROLL_PANE_BACKGROUND = getLocalizedColor("background", 0xFF000000);
+            SCROLL_PANE_OVERLAY_TOP = getLocalizedColor("overlayTop", 0xFFA0A0A0);
+            SCROLL_PANE_OVERLAY_BOTTOM = getLocalizedColor("overlayBottom", 0xFFA0A0A0);
+            SCROLL_PANE_OVERLAY_LEFT = getLocalizedColor("overlayLeft", 0xFFA0A0A0);
+            SCROLL_PANE_OVERLAY_RIGHT = getLocalizedColor("overlayRight", 0xFFA0A0A0);
+            SCROLLBAR_CORNERS = getLocalizedColor("scrollbarCorners", 0xFF8B8B8B);
+            SCROLLBAR_TOP_LEFT = getLocalizedColor("scrollbarTopLeft", 0xFFF0F0F0);
+            SCROLLBAR_BOTTOM_RIGHT = getLocalizedColor("scrollbarBottomRight", 0xFF555555);
+            SCROLLBAR_FILL = getLocalizedColor("scrollbarFill", 0xFFC6C6C6);
+            SCROLLBAR_GUIDE = getLocalizedColor("scrollbarGuide", 0xFF808080);
+            TOOLTIP_BG_START = getLocalizedColor("tooltipBgStart", 0xF0100010);
+            TOOLTIP_BG_END = getLocalizedColor("tooltipBgEnd", 0xF0100010);
+            TOOLTIP_BORDER_START = getLocalizedColor("tooltipBorderStart", 0x505000FF);
+            TOOLTIP_BORDER_END = getLocalizedColor("tooltipBorderEnd", 0x5028007F);
+            TOOLTIP_TEXT = getLocalizedColor("tooltipText", 0xFFFFFFFF);
+            ITEM_QUANTITY_TEXT = getLocalizedColor("itemQuantityText", 0xFFFFFF);
+            MOD_DESCRIPTION_TEXT = getLocalizedColor("modDescriptionText", 0xDDDDDD);
+        }
 
         /**
          * Resolve a optional localized ARGB color from lang files. Expected value format: AARRGGBB (for example

--- a/src/main/java/codechicken/lib/colour/Colour.java
+++ b/src/main/java/codechicken/lib/colour/Colour.java
@@ -3,8 +3,6 @@ package codechicken.lib.colour;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.minecraft.util.StatCollector;
-
 import org.lwjgl.opengl.GL11;
 
 import codechicken.lib.config.ConfigTag.IConfigType;
@@ -14,94 +12,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class Colour implements Copyable<Colour> {
-
-    public static final class LocalizedColours {
-
-        private static final String KEY_PREFIX = "codechickencore.color.";
-
-        public static int BUTTON_TEXT_DISABLED = 0xFFA0A0A0;
-        public static int BUTTON_TEXT_HOVER = 0xFFFFFFA0;
-        public static int BUTTON_TEXT = 0xFFE0E0E0;
-        public static int TEXT_FIELD_BORDER = 0xFFA0A0A0;
-        public static int TEXT_FIELD_BACKGROUND = 0xFF000000;
-        public static int TEXT_FIELD_TEXT = 0xE0E0E0;
-        public static int TEXT_FIELD_TEXT_DISABLED = 0x707070;
-        public static int SCROLL_PANE_BACKGROUND = 0xFF000000;
-        public static int SCROLL_PANE_OVERLAY_TOP = 0xFFA0A0A0;
-        public static int SCROLL_PANE_OVERLAY_BOTTOM = 0xFFA0A0A0;
-        public static int SCROLL_PANE_OVERLAY_LEFT = 0xFFA0A0A0;
-        public static int SCROLL_PANE_OVERLAY_RIGHT = 0xFFA0A0A0;
-        public static int SCROLLBAR_CORNERS = 0xFF8B8B8B;
-        public static int SCROLLBAR_TOP_LEFT = 0xFFF0F0F0;
-        public static int SCROLLBAR_BOTTOM_RIGHT = 0xFF555555;
-        public static int SCROLLBAR_FILL = 0xFFC6C6C6;
-        public static int SCROLLBAR_GUIDE = 0xFF808080;
-        public static int TOOLTIP_BG_START = 0xF0100010;
-        public static int TOOLTIP_BG_END = 0xF0100010;
-        public static int TOOLTIP_BORDER_START = 0x505000FF;
-        public static int TOOLTIP_BORDER_END = 0x5028007F;
-        public static int TOOLTIP_TEXT = 0xFFFFFFFF;
-        public static int ITEM_QUANTITY_TEXT = 0xFFFFFF;
-        public static int MOD_DESCRIPTION_TEXT = 0xDDDDDD;
-
-        private LocalizedColours() {}
-
-        public static void reloadLocalizedColours() {
-            BUTTON_TEXT_DISABLED = getLocalizedColor("buttonTextDisabled", BUTTON_TEXT_DISABLED);
-            BUTTON_TEXT_HOVER = getLocalizedColor("buttonTextHover", BUTTON_TEXT_HOVER);
-            BUTTON_TEXT = getLocalizedColor("buttonText", BUTTON_TEXT);
-            TEXT_FIELD_BORDER = getLocalizedColor("textFieldBorder", TEXT_FIELD_BORDER);
-            TEXT_FIELD_BACKGROUND = getLocalizedColor("textFieldBackground", TEXT_FIELD_BACKGROUND);
-            TEXT_FIELD_TEXT = getLocalizedColor("textFieldText", TEXT_FIELD_TEXT);
-            TEXT_FIELD_TEXT_DISABLED = getLocalizedColor("textFieldTextDisabled", TEXT_FIELD_TEXT_DISABLED);
-            SCROLL_PANE_BACKGROUND = getLocalizedColor("background", SCROLL_PANE_BACKGROUND);
-            SCROLL_PANE_OVERLAY_TOP = getLocalizedColor("overlayTop", SCROLL_PANE_OVERLAY_TOP);
-            SCROLL_PANE_OVERLAY_BOTTOM = getLocalizedColor("overlayBottom", SCROLL_PANE_OVERLAY_BOTTOM);
-            SCROLL_PANE_OVERLAY_LEFT = getLocalizedColor("overlayLeft", SCROLL_PANE_OVERLAY_LEFT);
-            SCROLL_PANE_OVERLAY_RIGHT = getLocalizedColor("overlayRight", SCROLL_PANE_OVERLAY_RIGHT);
-            SCROLLBAR_CORNERS = getLocalizedColor("scrollbarCorners", SCROLLBAR_CORNERS);
-            SCROLLBAR_TOP_LEFT = getLocalizedColor("scrollbarTopLeft", SCROLLBAR_TOP_LEFT);
-            SCROLLBAR_BOTTOM_RIGHT = getLocalizedColor("scrollbarBottomRight", SCROLLBAR_BOTTOM_RIGHT);
-            SCROLLBAR_FILL = getLocalizedColor("scrollbarFill", SCROLLBAR_FILL);
-            SCROLLBAR_GUIDE = getLocalizedColor("scrollbarGuide", SCROLLBAR_GUIDE);
-            TOOLTIP_BG_START = getLocalizedColor("tooltipBgStart", TOOLTIP_BG_START);
-            TOOLTIP_BG_END = getLocalizedColor("tooltipBgEnd", TOOLTIP_BG_END);
-            TOOLTIP_BORDER_START = getLocalizedColor("tooltipBorderStart", TOOLTIP_BORDER_START);
-            TOOLTIP_BORDER_END = getLocalizedColor("tooltipBorderEnd", TOOLTIP_BORDER_END);
-            TOOLTIP_TEXT = getLocalizedColor("tooltipText", TOOLTIP_TEXT);
-            ITEM_QUANTITY_TEXT = getLocalizedColor("itemQuantityText", ITEM_QUANTITY_TEXT);
-            MOD_DESCRIPTION_TEXT = getLocalizedColor("modDescriptionText", MOD_DESCRIPTION_TEXT);
-        }
-
-        /**
-         * Resolve a optional localized ARGB color from lang files. Expected value format: AARRGGBB (for example
-         * FF555555).
-         */
-        public static int getLocalizedColor(String key, int defaultColor) {
-            String fullKey = KEY_PREFIX + key;
-            if (!StatCollector.canTranslate(fullKey)) {
-                return defaultColor;
-            }
-
-            String raw = StatCollector.translateToLocal(fullKey);
-            if (raw == null) {
-                return defaultColor;
-            }
-
-            String hex = raw.trim();
-            if (hex.startsWith("0x") || hex.startsWith("0X")) {
-                hex = hex.substring(2);
-            } else if (hex.startsWith("#")) {
-                hex = hex.substring(1);
-            }
-
-            try {
-                return (int) Long.parseLong(hex, 16);
-            } catch (NumberFormatException ignored) {
-                return defaultColor;
-            }
-        }
-    }
 
     public static IConfigType<Colour> configRGB = new IConfigType<Colour>() {
 

--- a/src/main/java/codechicken/lib/colour/Colour.java
+++ b/src/main/java/codechicken/lib/colour/Colour.java
@@ -19,58 +19,58 @@ public abstract class Colour implements Copyable<Colour> {
 
         private static final String KEY_PREFIX = "codechickencore.color.";
 
-        public static int BUTTON_TEXT_DISABLED;
-        public static int BUTTON_TEXT_HOVER;
-        public static int BUTTON_TEXT;
-        public static int TEXT_FIELD_BORDER;
-        public static int TEXT_FIELD_BACKGROUND;
-        public static int TEXT_FIELD_TEXT;
-        public static int TEXT_FIELD_TEXT_DISABLED;
-        public static int SCROLL_PANE_BACKGROUND;
-        public static int SCROLL_PANE_OVERLAY_TOP;
-        public static int SCROLL_PANE_OVERLAY_BOTTOM;
-        public static int SCROLL_PANE_OVERLAY_LEFT;
-        public static int SCROLL_PANE_OVERLAY_RIGHT;
-        public static int SCROLLBAR_CORNERS;
-        public static int SCROLLBAR_TOP_LEFT;
-        public static int SCROLLBAR_BOTTOM_RIGHT;
-        public static int SCROLLBAR_FILL;
-        public static int SCROLLBAR_GUIDE;
-        public static int TOOLTIP_BG_START;
-        public static int TOOLTIP_BG_END;
-        public static int TOOLTIP_BORDER_START;
-        public static int TOOLTIP_BORDER_END;
-        public static int TOOLTIP_TEXT;
-        public static int ITEM_QUANTITY_TEXT;
-        public static int MOD_DESCRIPTION_TEXT;
+        public static int BUTTON_TEXT_DISABLED = 0xFFA0A0A0;
+        public static int BUTTON_TEXT_HOVER = 0xFFFFFFA0;
+        public static int BUTTON_TEXT = 0xFFE0E0E0;
+        public static int TEXT_FIELD_BORDER = 0xFFA0A0A0;
+        public static int TEXT_FIELD_BACKGROUND = 0xFF000000;
+        public static int TEXT_FIELD_TEXT = 0xE0E0E0;
+        public static int TEXT_FIELD_TEXT_DISABLED = 0x707070;
+        public static int SCROLL_PANE_BACKGROUND = 0xFF000000;
+        public static int SCROLL_PANE_OVERLAY_TOP = 0xFFA0A0A0;
+        public static int SCROLL_PANE_OVERLAY_BOTTOM = 0xFFA0A0A0;
+        public static int SCROLL_PANE_OVERLAY_LEFT = 0xFFA0A0A0;
+        public static int SCROLL_PANE_OVERLAY_RIGHT = 0xFFA0A0A0;
+        public static int SCROLLBAR_CORNERS = 0xFF8B8B8B;
+        public static int SCROLLBAR_TOP_LEFT = 0xFFF0F0F0;
+        public static int SCROLLBAR_BOTTOM_RIGHT = 0xFF555555;
+        public static int SCROLLBAR_FILL = 0xFFC6C6C6;
+        public static int SCROLLBAR_GUIDE = 0xFF808080;
+        public static int TOOLTIP_BG_START = 0xF0100010;
+        public static int TOOLTIP_BG_END = 0xF0100010;
+        public static int TOOLTIP_BORDER_START = 0x505000FF;
+        public static int TOOLTIP_BORDER_END = 0x5028007F;
+        public static int TOOLTIP_TEXT = 0xFFFFFFFF;
+        public static int ITEM_QUANTITY_TEXT = 0xFFFFFF;
+        public static int MOD_DESCRIPTION_TEXT = 0xDDDDDD;
 
         private LocalizedColours() {}
 
         public static void reloadLocalizedColours() {
-            BUTTON_TEXT_DISABLED = getLocalizedColor("buttonTextDisabled", 0xFFA0A0A0);
-            BUTTON_TEXT_HOVER = getLocalizedColor("buttonTextHover", 0xFFFFFFA0);
-            BUTTON_TEXT = getLocalizedColor("buttonText", 0xFFE0E0E0);
-            TEXT_FIELD_BORDER = getLocalizedColor("textFieldBorder", 0xFFA0A0A0);
-            TEXT_FIELD_BACKGROUND = getLocalizedColor("textFieldBackground", 0xFF000000);
-            TEXT_FIELD_TEXT = getLocalizedColor("textFieldText", 0xE0E0E0);
-            TEXT_FIELD_TEXT_DISABLED = getLocalizedColor("textFieldTextDisabled", 0x707070);
-            SCROLL_PANE_BACKGROUND = getLocalizedColor("background", 0xFF000000);
-            SCROLL_PANE_OVERLAY_TOP = getLocalizedColor("overlayTop", 0xFFA0A0A0);
-            SCROLL_PANE_OVERLAY_BOTTOM = getLocalizedColor("overlayBottom", 0xFFA0A0A0);
-            SCROLL_PANE_OVERLAY_LEFT = getLocalizedColor("overlayLeft", 0xFFA0A0A0);
-            SCROLL_PANE_OVERLAY_RIGHT = getLocalizedColor("overlayRight", 0xFFA0A0A0);
-            SCROLLBAR_CORNERS = getLocalizedColor("scrollbarCorners", 0xFF8B8B8B);
-            SCROLLBAR_TOP_LEFT = getLocalizedColor("scrollbarTopLeft", 0xFFF0F0F0);
-            SCROLLBAR_BOTTOM_RIGHT = getLocalizedColor("scrollbarBottomRight", 0xFF555555);
-            SCROLLBAR_FILL = getLocalizedColor("scrollbarFill", 0xFFC6C6C6);
-            SCROLLBAR_GUIDE = getLocalizedColor("scrollbarGuide", 0xFF808080);
-            TOOLTIP_BG_START = getLocalizedColor("tooltipBgStart", 0xF0100010);
-            TOOLTIP_BG_END = getLocalizedColor("tooltipBgEnd", 0xF0100010);
-            TOOLTIP_BORDER_START = getLocalizedColor("tooltipBorderStart", 0x505000FF);
-            TOOLTIP_BORDER_END = getLocalizedColor("tooltipBorderEnd", 0x5028007F);
-            TOOLTIP_TEXT = getLocalizedColor("tooltipText", 0xFFFFFFFF);
-            ITEM_QUANTITY_TEXT = getLocalizedColor("itemQuantityText", 0xFFFFFF);
-            MOD_DESCRIPTION_TEXT = getLocalizedColor("modDescriptionText", 0xDDDDDD);
+            BUTTON_TEXT_DISABLED = getLocalizedColor("buttonTextDisabled", BUTTON_TEXT_DISABLED);
+            BUTTON_TEXT_HOVER = getLocalizedColor("buttonTextHover", BUTTON_TEXT_HOVER);
+            BUTTON_TEXT = getLocalizedColor("buttonText", BUTTON_TEXT);
+            TEXT_FIELD_BORDER = getLocalizedColor("textFieldBorder", TEXT_FIELD_BORDER);
+            TEXT_FIELD_BACKGROUND = getLocalizedColor("textFieldBackground", TEXT_FIELD_BACKGROUND);
+            TEXT_FIELD_TEXT = getLocalizedColor("textFieldText", TEXT_FIELD_TEXT);
+            TEXT_FIELD_TEXT_DISABLED = getLocalizedColor("textFieldTextDisabled", TEXT_FIELD_TEXT_DISABLED);
+            SCROLL_PANE_BACKGROUND = getLocalizedColor("background", SCROLL_PANE_BACKGROUND);
+            SCROLL_PANE_OVERLAY_TOP = getLocalizedColor("overlayTop", SCROLL_PANE_OVERLAY_TOP);
+            SCROLL_PANE_OVERLAY_BOTTOM = getLocalizedColor("overlayBottom", SCROLL_PANE_OVERLAY_BOTTOM);
+            SCROLL_PANE_OVERLAY_LEFT = getLocalizedColor("overlayLeft", SCROLL_PANE_OVERLAY_LEFT);
+            SCROLL_PANE_OVERLAY_RIGHT = getLocalizedColor("overlayRight", SCROLL_PANE_OVERLAY_RIGHT);
+            SCROLLBAR_CORNERS = getLocalizedColor("scrollbarCorners", SCROLLBAR_CORNERS);
+            SCROLLBAR_TOP_LEFT = getLocalizedColor("scrollbarTopLeft", SCROLLBAR_TOP_LEFT);
+            SCROLLBAR_BOTTOM_RIGHT = getLocalizedColor("scrollbarBottomRight", SCROLLBAR_BOTTOM_RIGHT);
+            SCROLLBAR_FILL = getLocalizedColor("scrollbarFill", SCROLLBAR_FILL);
+            SCROLLBAR_GUIDE = getLocalizedColor("scrollbarGuide", SCROLLBAR_GUIDE);
+            TOOLTIP_BG_START = getLocalizedColor("tooltipBgStart", TOOLTIP_BG_START);
+            TOOLTIP_BG_END = getLocalizedColor("tooltipBgEnd", TOOLTIP_BG_END);
+            TOOLTIP_BORDER_START = getLocalizedColor("tooltipBorderStart", TOOLTIP_BORDER_START);
+            TOOLTIP_BORDER_END = getLocalizedColor("tooltipBorderEnd", TOOLTIP_BORDER_END);
+            TOOLTIP_TEXT = getLocalizedColor("tooltipText", TOOLTIP_TEXT);
+            ITEM_QUANTITY_TEXT = getLocalizedColor("itemQuantityText", ITEM_QUANTITY_TEXT);
+            MOD_DESCRIPTION_TEXT = getLocalizedColor("modDescriptionText", MOD_DESCRIPTION_TEXT);
         }
 
         /**

--- a/src/main/java/codechicken/lib/colour/LocalizedColours.java
+++ b/src/main/java/codechicken/lib/colour/LocalizedColours.java
@@ -69,11 +69,6 @@ public final class LocalizedColours {
             return defaultColor;
         }
 
-        String raw = StatCollector.translateToLocal(fullKey);
-        if (raw == null) {
-            return defaultColor;
-        }
-
         String hex = raw.trim();
         if (hex.startsWith("0x") || hex.startsWith("0X")) {
             hex = hex.substring(2);

--- a/src/main/java/codechicken/lib/colour/LocalizedColours.java
+++ b/src/main/java/codechicken/lib/colour/LocalizedColours.java
@@ -69,6 +69,7 @@ public final class LocalizedColours {
             return defaultColor;
         }
 
+        String raw = StatCollector.translateToLocal(fullKey);
         String hex = raw.trim();
         if (hex.startsWith("0x") || hex.startsWith("0X")) {
             hex = hex.substring(2);
@@ -77,7 +78,7 @@ public final class LocalizedColours {
         }
 
         try {
-            return (int) Integer.parseInt(hex, 16);
+            return (int) Long.parseLong(hex, 16);
         } catch (NumberFormatException ignored) {
             return defaultColor;
         }

--- a/src/main/java/codechicken/lib/colour/LocalizedColours.java
+++ b/src/main/java/codechicken/lib/colour/LocalizedColours.java
@@ -1,0 +1,90 @@
+package codechicken.lib.colour;
+
+import net.minecraft.util.StatCollector;
+
+public final class LocalizedColours {
+
+    private static final String KEY_PREFIX = "codechickencore.color.";
+
+    public static int BUTTON_TEXT_DISABLED = 0xFFA0A0A0;
+    public static int BUTTON_TEXT_HOVER = 0xFFFFFFA0;
+    public static int BUTTON_TEXT = 0xFFE0E0E0;
+    public static int TEXT_FIELD_BORDER = 0xFFA0A0A0;
+    public static int TEXT_FIELD_BACKGROUND = 0xFF000000;
+    public static int TEXT_FIELD_TEXT = 0xE0E0E0;
+    public static int TEXT_FIELD_TEXT_DISABLED = 0x707070;
+    public static int SCROLL_PANE_BACKGROUND = 0xFF000000;
+    public static int SCROLL_PANE_OVERLAY_TOP = 0xFFA0A0A0;
+    public static int SCROLL_PANE_OVERLAY_BOTTOM = 0xFFA0A0A0;
+    public static int SCROLL_PANE_OVERLAY_LEFT = 0xFFA0A0A0;
+    public static int SCROLL_PANE_OVERLAY_RIGHT = 0xFFA0A0A0;
+    public static int SCROLLBAR_CORNERS = 0xFF8B8B8B;
+    public static int SCROLLBAR_TOP_LEFT = 0xFFF0F0F0;
+    public static int SCROLLBAR_BOTTOM_RIGHT = 0xFF555555;
+    public static int SCROLLBAR_FILL = 0xFFC6C6C6;
+    public static int SCROLLBAR_GUIDE = 0xFF808080;
+    public static int TOOLTIP_BG_START = 0xF0100010;
+    public static int TOOLTIP_BG_END = 0xF0100010;
+    public static int TOOLTIP_BORDER_START = 0x505000FF;
+    public static int TOOLTIP_BORDER_END = 0x5028007F;
+    public static int TOOLTIP_TEXT = 0xFFFFFFFF;
+    public static int ITEM_QUANTITY_TEXT = 0xFFFFFF;
+    public static int MOD_DESCRIPTION_TEXT = 0xDDDDDD;
+
+    private LocalizedColours() {}
+
+    public static void reloadLocalizedColours() {
+        BUTTON_TEXT_DISABLED = getLocalizedColor("buttonTextDisabled", BUTTON_TEXT_DISABLED);
+        BUTTON_TEXT_HOVER = getLocalizedColor("buttonTextHover", BUTTON_TEXT_HOVER);
+        BUTTON_TEXT = getLocalizedColor("buttonText", BUTTON_TEXT);
+        TEXT_FIELD_BORDER = getLocalizedColor("textFieldBorder", TEXT_FIELD_BORDER);
+        TEXT_FIELD_BACKGROUND = getLocalizedColor("textFieldBackground", TEXT_FIELD_BACKGROUND);
+        TEXT_FIELD_TEXT = getLocalizedColor("textFieldText", TEXT_FIELD_TEXT);
+        TEXT_FIELD_TEXT_DISABLED = getLocalizedColor("textFieldTextDisabled", TEXT_FIELD_TEXT_DISABLED);
+        SCROLL_PANE_BACKGROUND = getLocalizedColor("background", SCROLL_PANE_BACKGROUND);
+        SCROLL_PANE_OVERLAY_TOP = getLocalizedColor("overlayTop", SCROLL_PANE_OVERLAY_TOP);
+        SCROLL_PANE_OVERLAY_BOTTOM = getLocalizedColor("overlayBottom", SCROLL_PANE_OVERLAY_BOTTOM);
+        SCROLL_PANE_OVERLAY_LEFT = getLocalizedColor("overlayLeft", SCROLL_PANE_OVERLAY_LEFT);
+        SCROLL_PANE_OVERLAY_RIGHT = getLocalizedColor("overlayRight", SCROLL_PANE_OVERLAY_RIGHT);
+        SCROLLBAR_CORNERS = getLocalizedColor("scrollbarCorners", SCROLLBAR_CORNERS);
+        SCROLLBAR_TOP_LEFT = getLocalizedColor("scrollbarTopLeft", SCROLLBAR_TOP_LEFT);
+        SCROLLBAR_BOTTOM_RIGHT = getLocalizedColor("scrollbarBottomRight", SCROLLBAR_BOTTOM_RIGHT);
+        SCROLLBAR_FILL = getLocalizedColor("scrollbarFill", SCROLLBAR_FILL);
+        SCROLLBAR_GUIDE = getLocalizedColor("scrollbarGuide", SCROLLBAR_GUIDE);
+        TOOLTIP_BG_START = getLocalizedColor("tooltipBgStart", TOOLTIP_BG_START);
+        TOOLTIP_BG_END = getLocalizedColor("tooltipBgEnd", TOOLTIP_BG_END);
+        TOOLTIP_BORDER_START = getLocalizedColor("tooltipBorderStart", TOOLTIP_BORDER_START);
+        TOOLTIP_BORDER_END = getLocalizedColor("tooltipBorderEnd", TOOLTIP_BORDER_END);
+        TOOLTIP_TEXT = getLocalizedColor("tooltipText", TOOLTIP_TEXT);
+        ITEM_QUANTITY_TEXT = getLocalizedColor("itemQuantityText", ITEM_QUANTITY_TEXT);
+        MOD_DESCRIPTION_TEXT = getLocalizedColor("modDescriptionText", MOD_DESCRIPTION_TEXT);
+    }
+
+    /**
+     * Resolve a optional localized ARGB color from lang files. Expected value format: AARRGGBB (for example FF555555).
+     */
+    private static int getLocalizedColor(String key, int defaultColor) {
+        String fullKey = KEY_PREFIX + key;
+        if (!StatCollector.canTranslate(fullKey)) {
+            return defaultColor;
+        }
+
+        String raw = StatCollector.translateToLocal(fullKey);
+        if (raw == null) {
+            return defaultColor;
+        }
+
+        String hex = raw.trim();
+        if (hex.startsWith("0x") || hex.startsWith("0X")) {
+            hex = hex.substring(2);
+        } else if (hex.startsWith("#")) {
+            hex = hex.substring(1);
+        }
+
+        try {
+            return (int) Integer.parseInt(hex, 16);
+        } catch (NumberFormatException ignored) {
+            return defaultColor;
+        }
+    }
+}

--- a/src/main/java/codechicken/lib/gui/GuiDraw.java
+++ b/src/main/java/codechicken/lib/gui/GuiDraw.java
@@ -18,7 +18,7 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.render.CCRenderState;
 

--- a/src/main/java/codechicken/lib/gui/GuiDraw.java
+++ b/src/main/java/codechicken/lib/gui/GuiDraw.java
@@ -18,7 +18,7 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.render.CCRenderState;
 
@@ -168,10 +168,10 @@ public class GuiDraw {
                 x,
                 y,
                 list,
-                Localized.getLocalizedColor("tooltipBgStart", 0xF0100010),
-                Localized.getLocalizedColor("tooltipBgEnd", 0xF0100010),
-                Localized.getLocalizedColor("tooltipBorderStart", 0x505000FF),
-                Localized.getLocalizedColor("tooltipBorderEnd", 0x5028007F));
+                LocalizedColours.TOOLTIP_BG_START,
+                LocalizedColours.TOOLTIP_BG_END,
+                LocalizedColours.TOOLTIP_BORDER_START,
+                LocalizedColours.TOOLTIP_BORDER_END);
     }
 
     public static void drawMultilineTip(FontRenderer font, int x, int y, List<String> list, int bgStart, int bgEnd,
@@ -210,7 +210,7 @@ public class GuiDraw {
                 line.draw(x, y);
                 y += line.getSize().height;
             } else {
-                font.drawStringWithShadow(s, x, y, Localized.getLocalizedColor("tooltipText", 0xFFFFFFFF));
+                font.drawStringWithShadow(s, x, y, LocalizedColours.TOOLTIP_TEXT);
                 y += s.endsWith(TOOLTIP_LINESPACE) ? 12 : 10;
             }
         }
@@ -229,10 +229,10 @@ public class GuiDraw {
                 y,
                 w,
                 h,
-                Localized.getLocalizedColor("tooltipBgStart", 0xF0100010),
-                Localized.getLocalizedColor("tooltipBgEnd", 0xF0100010),
-                Localized.getLocalizedColor("tooltipBorderStart", 0x505000FF),
-                Localized.getLocalizedColor("tooltipBorderEnd", 0x5028007F));
+                LocalizedColours.TOOLTIP_BG_START,
+                LocalizedColours.TOOLTIP_BG_END,
+                LocalizedColours.TOOLTIP_BORDER_START,
+                LocalizedColours.TOOLTIP_BORDER_END);
     }
 
     public static void drawTooltipBox(int x, int y, int w, int h, int bgStart, int bgEnd, int borderStart,

--- a/src/main/java/codechicken/lib/gui/GuiDraw.java
+++ b/src/main/java/codechicken/lib/gui/GuiDraw.java
@@ -18,6 +18,7 @@ import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import codechicken.lib.colour.Colour.Localized;
 import codechicken.lib.math.MathHelper;
 import codechicken.lib.render.CCRenderState;
 
@@ -162,7 +163,15 @@ public class GuiDraw {
     }
 
     public static void drawMultilineTip(FontRenderer font, int x, int y, List<String> list) {
-        drawMultilineTip(font, x, y, list, 0xf0100010, 0xf0100010, 0x505000ff, 0x5028007F);
+        drawMultilineTip(
+                font,
+                x,
+                y,
+                list,
+                Localized.getLocalizedColor("tooltipBgStart", 0xF0100010),
+                Localized.getLocalizedColor("tooltipBgEnd", 0xF0100010),
+                Localized.getLocalizedColor("tooltipBorderStart", 0x505000FF),
+                Localized.getLocalizedColor("tooltipBorderEnd", 0x5028007F));
     }
 
     public static void drawMultilineTip(FontRenderer font, int x, int y, List<String> list, int bgStart, int bgEnd,
@@ -201,7 +210,7 @@ public class GuiDraw {
                 line.draw(x, y);
                 y += line.getSize().height;
             } else {
-                font.drawStringWithShadow(s, x, y, -1);
+                font.drawStringWithShadow(s, x, y, Localized.getLocalizedColor("tooltipText", 0xFFFFFFFF));
                 y += s.endsWith(TOOLTIP_LINESPACE) ? 12 : 10;
             }
         }
@@ -215,7 +224,15 @@ public class GuiDraw {
     }
 
     public static void drawTooltipBox(int x, int y, int w, int h) {
-        drawTooltipBox(x, y, w, h, 0xf0100010, 0xf0100010, 0x505000ff, 0x5028007F);
+        drawTooltipBox(
+                x,
+                y,
+                w,
+                h,
+                Localized.getLocalizedColor("tooltipBgStart", 0xF0100010),
+                Localized.getLocalizedColor("tooltipBgEnd", 0xF0100010),
+                Localized.getLocalizedColor("tooltipBorderStart", 0x505000FF),
+                Localized.getLocalizedColor("tooltipBorderEnd", 0x5028007F));
     }
 
     public static void drawTooltipBox(int x, int y, int w, int h, int bgStart, int bgEnd, int borderStart,

--- a/src/main/java/codechicken/lib/render/FontUtils.java
+++ b/src/main/java/codechicken/lib/render/FontUtils.java
@@ -6,7 +6,7 @@ import net.minecraft.item.ItemStack;
 
 import org.lwjgl.opengl.GL11;
 
-import codechicken.lib.colour.Colour.LocalizedColours;
+import codechicken.lib.colour.LocalizedColours;
 
 public class FontUtils {
 

--- a/src/main/java/codechicken/lib/render/FontUtils.java
+++ b/src/main/java/codechicken/lib/render/FontUtils.java
@@ -6,7 +6,7 @@ import net.minecraft.item.ItemStack;
 
 import org.lwjgl.opengl.GL11;
 
-import codechicken.lib.colour.Colour.Localized;
+import codechicken.lib.colour.Colour.LocalizedColours;
 
 public class FontUtils {
 
@@ -55,7 +55,7 @@ public class FontUtils {
         GL11.glPushMatrix();
         GL11.glTranslated(x + 16 - swidth, y + 16 - sheight, 0);
         GL11.glScaled(scale, scale, 1);
-        fontRenderer.drawStringWithShadow(quantity, 0, 0, Localized.getLocalizedColor("itemQuantityText", 0xFFFFFF));
+        fontRenderer.drawStringWithShadow(quantity, 0, 0, LocalizedColours.ITEM_QUANTITY_TEXT);
         GL11.glPopMatrix();
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_DEPTH_TEST);

--- a/src/main/java/codechicken/lib/render/FontUtils.java
+++ b/src/main/java/codechicken/lib/render/FontUtils.java
@@ -6,6 +6,8 @@ import net.minecraft.item.ItemStack;
 
 import org.lwjgl.opengl.GL11;
 
+import codechicken.lib.colour.Colour.Localized;
+
 public class FontUtils {
 
     public static FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
@@ -53,7 +55,7 @@ public class FontUtils {
         GL11.glPushMatrix();
         GL11.glTranslated(x + 16 - swidth, y + 16 - sheight, 0);
         GL11.glScaled(scale, scale, 1);
-        fontRenderer.drawStringWithShadow(quantity, 0, 0, 0xFFFFFF);
+        fontRenderer.drawStringWithShadow(quantity, 0, 0, Localized.getLocalizedColor("itemQuantityText", 0xFFFFFF));
         GL11.glPopMatrix();
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_DEPTH_TEST);

--- a/src/main/resources/assets/codechickencore/lang/en_US.lang
+++ b/src/main/resources/assets/codechickencore/lang/en_US.lang
@@ -1,1 +1,26 @@
 codechickencore.update=Version %s of %s is available
+
+codechickencore.color.buttonTextDisabled=FFA0A0A0
+codechickencore.color.buttonTextHover=FFFFFFA0
+codechickencore.color.buttonText=FFE0E0E0
+codechickencore.color.textFieldBorder=FFA0A0A0
+codechickencore.color.textFieldBackground=FF000000
+codechickencore.color.textFieldText=E0E0E0
+codechickencore.color.textFieldTextDisabled=707070
+codechickencore.color.background=FF000000
+codechickencore.color.overlayTop=FFA0A0A0
+codechickencore.color.overlayBottom=FFA0A0A0
+codechickencore.color.overlayLeft=FFA0A0A0
+codechickencore.color.overlayRight=FFA0A0A0
+codechickencore.color.scrollbarCorners=FF8B8B8B
+codechickencore.color.scrollbarTopLeft=FFF0F0F0
+codechickencore.color.scrollbarBottomRight=FF555555
+codechickencore.color.scrollbarFill=FFC6C6C6
+codechickencore.color.scrollbarGuide=FF808080
+codechickencore.color.tooltipBgStart=F0100010
+codechickencore.color.tooltipBgEnd=F0100010
+codechickencore.color.tooltipBorderStart=505000FF
+codechickencore.color.tooltipBorderEnd=5028007F
+codechickencore.color.tooltipText=FFFFFFFF
+codechickencore.color.itemQuantityText=FFFFFF
+codechickencore.color.modDescriptionText=DDDDDD


### PR DESCRIPTION
Added the color helper which checks the lang key for corresponding keys, if not present, fallsback to default values. That gives the ability to edit the color with the resource pack.

Current optional keys:
```
codechickencore.color.background=FF000000
codechickencore.color.overlayTop=FFA0A0A0
codechickencore.color.overlayBottom=FFA0A0A0
codechickencore.color.overlayLeft=FFA0A0A0
codechickencore.color.overlayRight=FFA0A0A0
codechickencore.color.scrollbarCorners=FF8B8B8B
codechickencore.color.scrollbarTopLeft=FFF0F0F0
codechickencore.color.scrollbarBottomRight=FF555555
codechickencore.color.scrollbarFill=FFC6C6C6
codechickencore.color.scrollbarGuide=FF808080
codechickencore.color.buttonTextDisabled=FFA0A0A0
codechickencore.color.buttonTextHover=FFFFFFA0
codechickencore.color.buttonText=FFE0E0E0
codechickencore.color.textFieldBorder=FFA0A0A0
codechickencore.color.textFieldBackground=FF000000
codechickencore.color.textFieldText=00E0E0E0
codechickencore.color.textFieldTextDisabled=00707070
codechickencore.color.tooltipBgStart=F0100010
codechickencore.color.tooltipBgEnd=F0100010
codechickencore.color.tooltipBorderStart=505000FF
codechickencore.color.tooltipBorderEnd=5028007F
codechickencore.color.tooltipText=FFFFFFFF
codechickencore.color.modDescriptionText=00DDDDDD
codechickencore.color.itemQuantityText=00FFFFFF
```

Also removed the comments from `GuiScrollPane.java`, because the helper already indicated the target