### PR TITLE
NPE check on onChunkUnload

### DIFF
--- a/src/main/java/codechicken/lib/world/WorldExtensionManager.java
+++ b/src/main/java/codechicken/lib/world/WorldExtensionManager.java
@@ -55,7 +55,10 @@ public class WorldExtensionManager {
         public void onChunkUnLoad(ChunkEvent.Unload event) {
             if (event.getChunk() instanceof EmptyChunk) return;
 
-            for (WorldExtension extension : worldMap.get(event.world)) extension.unloadChunk(event.getChunk());
+            WorldExtension[] extensions = worldMap.get(event.world);
+            if (extensions == null) return;
+
+            for (WorldExtension extension : extensions) extension.unloadChunk(event.getChunk());
 
             if (event.world.isRemote) removeChunk(event.world, event.getChunk());
         }


### PR DESCRIPTION
## Summary
Prevent a NullPointException on chunk unload.

I have found this crash while browsing through my test server.
I am unsure on how it can even happen or how to even reproduce it.
That's the simplest solution I could come up with although I am unsure if it is the most appropriate so I'd love a second opinion.

This was with CodeChickenLib but I checked the new merge and the methods inherited weren't changed since.

Crash report:
https://pastebin.com/n5Ab32Gn

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
