### PR TITLE
Deprecate index-based field selection

### DIFF
--- a/src/main/java/codechicken/core/ReflectionManager.java
+++ b/src/main/java/codechicken/core/ReflectionManager.java
@@ -104,7 +104,7 @@ public class ReflectionManager {
      *                                  doesn't match the type of the field.
      * @throws IllegalAccessException   If unable to write to the field.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static void setField(Class<?> class1, Object instance, int fieldindex, Object value)
             throws IllegalArgumentException, IllegalAccessException {
         Field field = class1.getDeclaredFields()[fieldindex];
@@ -210,7 +210,7 @@ public class ReflectionManager {
      * @throws IllegalAccessException   If unable to read from the field.
      * @throws ClassCastException       If the object stored in the field is not a subclass of {@code fieldType}
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static <T> T getField(Class<?> class1, Class<T> fieldType, Object instance, int fieldIndex)
             throws IllegalArgumentException, IllegalAccessException {
         Field field = class1.getDeclaredFields()[fieldIndex];

--- a/src/main/java/codechicken/core/ReflectionManager.java
+++ b/src/main/java/codechicken/core/ReflectionManager.java
@@ -89,6 +89,22 @@ public class ReflectionManager {
         }
     }
 
+    /**
+     * Set a field of the object {@code instance} of type {@code class1} to {@code value}.
+     *
+     * @deprecated According to {@link Class#getDeclaredFields()}, the array of fields has no defined order, therefore
+     *             selecting a field based on its index will result in JVM-specific behaviour. Use
+     *             {@link #setField(Class, Object, String, Object)} instead.
+     *
+     * @param class1     The class which defines the field in question.
+     * @param instance   The object being altered - must be an instance of {@code class1}
+     * @param fieldindex The index of the field being set.
+     * @param value      The value to set the field to.
+     * @throws IllegalArgumentException If {@code instance} is not an instance of {@code class1}, or if {@code value}
+     *                                  doesn't match the type of the field.
+     * @throws IllegalAccessException   If unable to write to the field.
+     */
+    @Deprecated(forRemoval = true)
     public static void setField(Class<?> class1, Object instance, int fieldindex, Object value)
             throws IllegalArgumentException, IllegalAccessException {
         Field field = class1.getDeclaredFields()[fieldindex];
@@ -179,6 +195,22 @@ public class ReflectionManager {
         return null;
     }
 
+    /**
+     * Get a field of the object {@code instance} of type {@code class1}.
+     *
+     * @deprecated According to {@link Class#getDeclaredFields()}, the array of fields has no defined order, therefore
+     *             selecting a field based on its index will result in JVM-specific behaviour. Use
+     *             {@link #getField(Class, Class, Object, String)} instead.
+     *
+     * @param class1     The class which defines the field in question.
+     * @param fieldType  The type of the field being read.
+     * @param instance   The object being read from - must be an instance of {@code class1}
+     * @param fieldIndex The index of the field being read.
+     * @throws IllegalArgumentException If {@code instance} is not an instance of {@code class1}.
+     * @throws IllegalAccessException   If unable to read from the field.
+     * @throws ClassCastException       If the object stored in the field is not a subclass of {@code fieldType}
+     */
+    @Deprecated(forRemoval = true)
     public static <T> T getField(Class<?> class1, Class<T> fieldType, Object instance, int fieldIndex)
             throws IllegalArgumentException, IllegalAccessException {
         Field field = class1.getDeclaredFields()[fieldIndex];

--- a/src/main/java/codechicken/core/ReflectionManager.java
+++ b/src/main/java/codechicken/core/ReflectionManager.java
@@ -208,7 +208,6 @@ public class ReflectionManager {
      * @param fieldIndex The index of the field being read.
      * @throws IllegalArgumentException If {@code instance} is not an instance of {@code class1}.
      * @throws IllegalAccessException   If unable to read from the field.
-     * @throws ClassCastException       If the object stored in the field is not a subclass of {@code fieldType}
      */
     @Deprecated
     public static <T> T getField(Class<?> class1, Class<T> fieldType, Object instance, int fieldIndex)


### PR DESCRIPTION
## Summary
Selecting fields based on their index within `getDeclaredFields()` is undefined behavior. According to the [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--) for `getDeclaredFields()`, the returned fields "are not in any particular order," which makes getting fields by their index incorrect.

Also, this method makes the code really difficult to read, since the source code doesn't contain the name of the field that the code is trying to read/write to.

This PR deprecates the two methods, so we can remove them from mods that rely on CodeChickenCore in the future.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack - Irrelevant, annotation-only changes.
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
