### PR TITLE
Fixing silly read write issue

### DIFF
--- a/src/main/java/codechicken/lib/packet/PacketCustom.java
+++ b/src/main/java/codechicken/lib/packet/PacketCustom.java
@@ -466,7 +466,7 @@ public final class PacketCustom implements MCDataInput, MCDataOutput {
 
     public FluidStack readFluidStack() {
         Fluid fluid = FluidRegistry.getFluid(readShort());
-        if (fluid == null) fluid = FluidRegistry.WATER;
+        if (fluid == null) return null;
 
         return new FluidStack(fluid, readVarInt(), readNBTTagCompound());
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Previously, if you read using this: https://github.com/GTNewHorizons/CodeChickenCore/blob/b738e8e073d1f90d3348200aad7d11516821867d/src/main/java/codechicken/lib/packet/PacketCustom.java#L467-L472

and wrote using this: https://github.com/GTNewHorizons/CodeChickenCore/blob/b738e8e073d1f90d3348200aad7d11516821867d/src/main/java/codechicken/lib/packet/PacketCustom.java#L370-L379

You're going crash for reading bad stuff in the buffer probably. This fixes that.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
